### PR TITLE
Fix resize value

### DIFF
--- a/scripts/mount-resize
+++ b/scripts/mount-resize
@@ -8,8 +8,15 @@ cd scripts
 
 resize_img_to_edit(){
 		getsize=$(ls -nl $DIRROM/$valset.img | awk '{print $5}')
+		readmb=$(($getsize / 100000000))
 		readgiga=$(($getsize / 1000000000))
-		sizeimg=$(($readgiga + 1))G
+		cval=$(($readmb - $readgiga))
+		if [[ $cval -gt 5 ]]; then
+			vplus=2;
+		else
+			vplus=1;
+		fi
+		sizeimg=$(($readgiga + $vplus))G
 		fallocate -l $sizeimg $DIRROM/$valset.img
 		e2fsck -yf $DIRROM/$valset.img
 		resize2fs $DIRROM/$valset.img $sizeimg


### PR DESCRIPTION
Fix resize value 0.5 - 0.9 GB

sebagai contoh. vendor.img memiliki ukuran 1.9GB
pada script resize sebelumnya hanya membaca 1GB saja.. tambah pembacaan dalam bentuk MB untuk mengetahui ukuran asli jika ukuran lebih dari 1,5 - 1,9 maka akan dibaca dengan ukuran 2GB